### PR TITLE
Update Ubuntu version, transition from bintray

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
-ENV INSTALL_KEY=379CE192D401AB61
-ENV DEB_DISTRO=bionic
+ENV DEB_DISTRO=focal
+ENV GPG_KEY_URL=https://packagecloud.io/ookla/speedtest-cli/gpgkey
+ENV GPG_KEY_ID=8E61C2AB9A6D1557
 
-RUN apt update && apt-get install gnupg1 apt-transport-https dirmngr -y
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $INSTALL_KEY
-RUN echo "deb https://ookla.bintray.com/debian ${DEB_DISTRO} main" | tee  /etc/apt/sources.list.d/speedtest.list
-RUN apt-get update && apt-get install speedtest
+RUN apt update && apt install gnupg1 apt-transport-https dirmngr curl -y
+RUN echo "deb https://packagecloud.io/ookla/speedtest-cli/ubuntu/ ${DEB_DISTRO} main\ndeb-src https://packagecloud.io/ookla/speedtest-cli/ubuntu/ ${DEB_DISTRO} main" | tee  /etc/apt/sources.list.d/speedtest.list
+RUN curl -L "${GPG_KEY_URL}" 2> /dev/null | apt-key add - &>/dev/null && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${GPG_KEY_ID} && apt update && apt install speedtest -y
 
 CMD ["speedtest", "-p", "no", "-f", "json-pretty", "--accept-license", "--accept-gdpr"]


### PR DESCRIPTION
Bintray was shut down on May 1st 2021.

This PR moves the Dockerfile away from Bintray on to packagecloud.io, Ookla's new provider as per their [website](https://www.speedtest.net/apps/cli).

This doesn't use the `install.deb.sh` script they provide for security and transparency reasons.